### PR TITLE
Fixed typo in update message

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ set the valiavles in the launch.json file.
 
 ### changing log level
 
-For debuging phoityen itself, change the log level to DEBUG.  
+For debugging phoityne itself, change the log level to DEBUG.  
 Adding Issue with the debug log.
 
     % diff .vscode/launch.json.old .vscode/launch.json

--- a/app/Phoityne/VSCode/Core.hs
+++ b/app/Phoityne/VSCode/Core.hs
@@ -274,7 +274,7 @@ _TASKS_JSON_FILE_CONTENTS = str2lbs $ U.join "\n" $
 --
 --
 _ERR_MSG_URL :: [String]
-_ERR_MSG_URL = [ "`stack update` and install new phoityen-vscode."
+_ERR_MSG_URL = [ "`stack update` and install new phoityne-vscode."
                , "Or check information on https://marketplace.visualstudio.com/items?itemName=phoityne.phoityne-vscode"
                ]
 
@@ -299,7 +299,7 @@ _NEW_VERSION_MSG :: [String]
 _NEW_VERSION_MSG = [
     ""
   , "  New hackage module has been released."
-  , "  `stack update` and `stack install phoityen-vscode`."
+  , "  `stack update` and `stack install phoityne-vscode`."
   , " "
   , " "
   ]


### PR DESCRIPTION
Fixed a typo in the "New hackage module has been released" message - currently, it reads:

![screenshot from 2018-10-28 17-26-40](https://user-images.githubusercontent.com/1362156/47619496-3e216580-dad7-11e8-9158-4bd61db63652.png)

Running the second code snippet fails as `phoityen-vscode` is a typo of `phoityne-vscode`.