### PR TITLE
fix: missing StateActivityIF for ContaminatedStateData

### DIFF
--- a/src/Haskell/Debug/Adapter/State/Contaminated.hs
+++ b/src/Haskell/Debug/Adapter/State/Contaminated.hs
@@ -45,6 +45,7 @@ instance AppStateIF ContaminatedStateData where
   doActivity s (WrapRequest r@StackTraceRequest{})              = action s r
   doActivity s (WrapRequest r@ScopesRequest{})                  = action s r
   doActivity s (WrapRequest r@VariablesRequest{})               = action s r
+  doActivity s (WrapRequest r@SourceRequest{})               = action s r
   doActivity s (WrapRequest r@ContinueRequest{})                = action s r
   doActivity s (WrapRequest r@NextRequest{})                    = action s r
   doActivity s (WrapRequest r@StepInRequest{})                  = action s r
@@ -207,6 +208,22 @@ instance StateActivityIF ContaminatedStateData DAP.VariablesRequest where
             }
 
     U.addResponse $ VariablesResponse res
+    return Nothing
+
+-- |
+--  Any errors should be sent back as False result Response
+--
+instance StateActivityIF ContaminatedStateData DAP.SourceRequest where
+  action _ (SourceRequest req) = do
+    resSeq <- U.getIncreasedResponseSequence
+    let res = DAP.defaultSourceResponse {
+        DAP.seqSourceResponse = resSeq
+      , DAP.request_seqSourceResponse = DAP.seqSourceRequest req
+      , DAP.successSourceResponse = False
+      , DAP.messageSourceResponse = "Contaminated State. need restart."
+      }
+
+    U.addResponse $ SourceResponse res
     return Nothing
 
 -- |


### PR DESCRIPTION
https://github.com/phoityne/haskell-debug-adapter/pull/27 introduces the following warning.
```
Building library for haskell-debug-adapter-0.0.38.0..
[17 of 31] Compiling Haskell.Debug.Adapter.State.Contaminated ( src/Haskell/Debug/Adapter/State/Contaminated.hs, /work/haskell/haskell-debug-adapter/dist-newstyle/build/x86_64-linux/ghc-9.4.2/haskell-debug-adapter-0.0.38.0/build/Haskell/Debug/Adapter/State/Contaminated.o, /work/haskell/haskell-debug-adapter/dist-newstyle/build/x86_64-linux/ghc-9.4.2/haskell-debug-adapter-0.0.38.0/build/Haskell/Debug/Adapter/State/Contaminated.dyn_o )

src/Haskell/Debug/Adapter/State/Contaminated.hs:35:3: warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In an equation for ‘doActivity’:
        Patterns of type ‘AppState ContaminatedStateData’,
                         ‘WrapRequest’ not matched:
            _ (WrapRequest (SourceRequest _))
   |
35 |   doActivity s (WrapRequest r@InitializeRequest{})              = action s r
```

I added the implemention of StateActivityIF for ContaminatedStateData.