### PR TITLE
feat: add nix build infrastructure + github workflow for tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake -Lv

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,12 @@
+name: "Nix build"
+on:
+  pull_request:
+  push:
+    branches: [master]
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+    - run: nix flake check -L --show-trace

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+stack.yaml.lock
+.stack-work
+.pre-commit-config.yaml
+result*
+dist-newstyle
+.direnv
+hie.yaml

--- a/README.md
+++ b/README.md
@@ -50,11 +50,27 @@ or
 > nix run .#haskell-debug-adapter
 ```
 
-To run all tests with nix:
+# Development
+
+This project can be built with stack, cabal and nix.
+
+To run all tests and checks with nix:
 
 ```console
 > nix flake check -L
 ```
+
+To enter a development shell with nix:
+
+```console
+> nix develop
+```
+
+> **Note**
+>
+> The `stack.yaml` and `cabal.project` assume that [`haskell-dap`](https://github.com/phoityne/haskell-dap)
+> and [`ghci-dap`](https://github.com/phoityne/ghci-dap) are checked out in the same directory as
+> this project. If they are not, `haskell-language-server` will fail to start.
 
 
 # Limitation

--- a/README.md
+++ b/README.md
@@ -34,8 +34,26 @@ Changed package name (because a name "phoityne-vscode" is ambiguous.), and with 
 
 Install these libraries at once.
 
-```
+```console
 > stack install haskell-dap ghci-dap haskell-debug-adapter
+```
+
+You can also build and run this project with nix:
+
+```console
+> nix build .#haskell-debug-adapter
+```
+
+or
+
+```console
+> nix run .#haskell-debug-adapter
+```
+
+To run all tests with nix:
+
+```console
+> nix flake check -L
 ```
 
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, aeson, async, base, bytestring, Cabal, clock
+, conduit, conduit-extra, containers, data-default, directory
+, filepath, fsnotify, ghci-dap, haskell-dap, hslogger, hspec, lens
+, lib, mtl, optparse-applicative, parsec, process, resourcet
+, safe-exceptions, text
+}:
+mkDerivation {
+  pname = "haskell-debug-adapter";
+  version = "0.0.39.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson async base bytestring Cabal clock conduit conduit-extra
+    containers data-default directory filepath fsnotify ghci-dap
+    haskell-dap hslogger lens mtl optparse-applicative parsec process
+    resourcet safe-exceptions text
+  ];
+  executableHaskellDepends = [
+    aeson async base bytestring Cabal clock conduit conduit-extra
+    containers data-default directory filepath fsnotify ghci-dap
+    haskell-dap hslogger lens mtl optparse-applicative parsec process
+    resourcet safe-exceptions text
+  ];
+  testHaskellDepends = [
+    aeson async base bytestring Cabal clock conduit conduit-extra
+    containers data-default directory filepath fsnotify ghci-dap
+    haskell-dap hslogger hspec lens mtl optparse-applicative parsec
+    process resourcet safe-exceptions text
+  ];
+  homepage = "https://github.com/phoityne/haskell-debug-adapter/";
+  description = "Haskell Debug Adapter";
+  license = lib.licenses.bsd3;
+  mainProgram = "haskell-debug-adapter";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -32,16 +32,48 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681037374,
-        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -51,6 +83,24 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -65,7 +115,119 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghci-dap": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1682640639,
+        "narHash": "sha256-Nsu9abxI3Un19ezOwmDaHwzhNv9yrSwWEIARu8YD7+Y=",
+        "owner": "phoityne",
+        "repo": "ghci-dap",
+        "rev": "1f2a245420618519d636ba700277787b06345c35",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phoityne",
+        "repo": "ghci-dap",
+        "type": "github"
+      }
+    },
     "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "ghci-dap",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "haskell-dap",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
       "inputs": {
         "nixpkgs": [
           "pre-commit-hooks",
@@ -86,13 +248,33 @@
         "type": "github"
       }
     },
+    "haskell-dap": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1682076556,
+        "narHash": "sha256-qMQGonmlUX/Q6TfuNGAWcsoxj5BvFomDXqORefTjPnQ=",
+        "owner": "phoityne",
+        "repo": "haskell-dap",
+        "rev": "87ce20532fc527eb205262fde16172ff4cca1242",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phoityne",
+        "repo": "haskell-dap",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681092589,
-        "narHash": "sha256-I11GYL+6yD6dX89H0WaMiptE52NZ2Tmx+rA23TUyfH8=",
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83ca2cd74539fb8e79d46e233f6bb1d978c36f32",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
         "type": "github"
       },
       "original": {
@@ -118,22 +300,136 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_3": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1682566018,
+        "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8e3b64db39f2aaa14b35ee5376bd6a2e707cadc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": [
+          "ghci-dap",
           "nixpkgs"
         ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1680981441,
-        "narHash": "sha256-Tqr2mCVssUVp1ZXXMpgYs9+ZonaWrZGPGltJz94FYi4=",
+        "lastModified": 1681227715,
+        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2144d9ddcb550d6dce64a2b44facdc8c5ea2e28a",
+        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_5",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "haskell-dap",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1681227715,
+        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_6",
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_3"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
         "type": "github"
       },
       "original": {
@@ -146,11 +442,43 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "ghci-dap": "ghci-dap",
+        "haskell-dap": "haskell-dap",
+        "nixpkgs": "nixpkgs_3",
+        "pre-commit-hooks": "pre-commit-hooks_3"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,171 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681037374,
+        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681092589,
+        "narHash": "sha256-I11GYL+6yD6dX89H0WaMiptE52NZ2Tmx+rA23TUyfH8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "83ca2cd74539fb8e79d46e233f6bb1d978c36f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1680981441,
+        "narHash": "sha256-Tqr2mCVssUVp1ZXXMpgYs9+ZonaWrZGPGltJz94FYi4=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "2144d9ddcb550d6dce64a2b44facdc8c5ea2e28a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,12 +54,16 @@
 
       devShell = pkgs.haskellPackages.shellFor {
         name = "haskell-debug-adapter-devShell";
-        packages = p: with p; [haskell-debug-adapter];
+        packages = p:
+          with p; [
+            haskell-debug-adapter
+          ];
         withHoogle = true;
         buildInputs =
           (with pkgs; [
             haskell-language-server
             cabal-install
+            haskellPackages.implicit-hie
             zlib
           ])
           ++ (with pre-commit-hooks.packages.${system}; [
@@ -68,6 +72,7 @@
             alejandra
           ]);
         shellHook = ''
+          gen-hie --cabal > hie.yaml
           ${self.checks.${system}.pre-commit-check.shellHook}
         '';
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Debug Adapter for Haskell debugging system.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    pre-commit-hooks,
+    flake-utils,
+    ...
+  }: let
+    supportedSystems = [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    overlay = import ./nix/overlay.nix;
+  in
+    flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          overlay
+        ];
+      };
+
+      pre-commit-check = pre-commit-hooks.lib.${system}.run {
+        src = self;
+        hooks = {
+          cabal2nix.enable = true;
+          alejandra.enable = true;
+          hpack.enable = true;
+        };
+        settings = {
+          alejandra.exclude = ["default.nix"];
+        };
+      };
+
+      devShell = pkgs.haskellPackages.shellFor {
+        name = "haskell-debug-adapter-devShell";
+        packages = p: with p; [haskell-debug-adapter];
+        withHoogle = true;
+        buildInputs =
+          (with pkgs; [
+            haskell-language-server
+            cabal-install
+            zlib
+          ])
+          ++ (with pre-commit-hooks.packages.${system}; [
+            hpack
+            cabal2nix
+            alejandra
+          ]);
+        shellHook = ''
+          ${self.checks.${system}.pre-commit-check.shellHook}
+        '';
+      };
+    in {
+      devShells = {
+        default = devShell;
+      };
+
+      overlays = overlay;
+
+      packages = rec {
+        default = haskell-debug-adapter;
+        haskell-debug-adapter = pkgs.haskellPackages.haskell-debug-adapter;
+      };
+
+      checks = {
+        inherit pre-commit-check;
+        haskell-debug-adapter = self.packages.${system}.default;
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
+    haskell-dap.url = "github:phoityne/haskell-dap";
+
+    ghci-dap.url = "github:phoityne/ghci-dap";
+
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -20,6 +24,8 @@
   outputs = {
     self,
     nixpkgs,
+    haskell-dap,
+    ghci-dap,
     pre-commit-hooks,
     flake-utils,
     ...
@@ -37,6 +43,8 @@
         inherit system;
         overlays = [
           overlay
+          haskell-dap.overlays.default
+          ghci-dap.overlays.default
         ];
       };
 
@@ -81,8 +89,6 @@
         default = devShell;
       };
 
-      overlays = overlay;
-
       packages = rec {
         default = haskell-debug-adapter;
         haskell-debug-adapter = pkgs.haskellPackages.haskell-debug-adapter;
@@ -92,5 +98,8 @@
         inherit pre-commit-check;
         haskell-debug-adapter = self.packages.${system}.default;
       };
-    });
+    })
+    // {
+      overlays.default = overlay;
+    };
 }

--- a/haskell-debug-adapter.cabal
+++ b/haskell-debug-adapter.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1a8a9f4202a32a5d5c37c676b9d919068955c6ff8fecee95e75927238459e56d
+-- hash: 31df6f8a3983d139dd38dfb23e6a70668fe0e158220e5b7a993db5050d161c30
 
 name:           haskell-debug-adapter
 version:        0.0.39.0
@@ -112,8 +112,8 @@ library
     , directory
     , filepath
     , fsnotify
-    , ghci-dap >=0.0.20.0
-    , haskell-dap >=0.0.16.0
+    , ghci-dap >=0.0.19.0
+    , haskell-dap >=0.0.15.0
     , hslogger
     , lens
     , mtl
@@ -123,9 +123,9 @@ library
     , resourcet
     , safe-exceptions
     , text
+  default-language: Haskell2010
   if impl(ghc < 8.10.0)
     buildable: False
-  default-language: Haskell2010
 
 executable haskell-debug-adapter
   main-is: Main.hs
@@ -186,8 +186,8 @@ executable haskell-debug-adapter
     , directory
     , filepath
     , fsnotify
-    , ghci-dap >=0.0.20.0
-    , haskell-dap >=0.0.16.0
+    , ghci-dap >=0.0.19.0
+    , haskell-dap >=0.0.15.0
     , haskell-debug-adapter
     , hslogger
     , lens
@@ -198,9 +198,9 @@ executable haskell-debug-adapter
     , resourcet
     , safe-exceptions
     , text
+  default-language: Haskell2010
   if impl(ghc < 8.10.0)
     buildable: False
-  default-language: Haskell2010
 
 test-suite haskell-debug-adapter-test
   type: exitcode-stdio-1.0
@@ -264,8 +264,8 @@ test-suite haskell-debug-adapter-test
     , directory
     , filepath
     , fsnotify
-    , ghci-dap >=0.0.20.0
-    , haskell-dap >=0.0.16.0
+    , ghci-dap >=0.0.19.0
+    , haskell-dap >=0.0.15.0
     , haskell-debug-adapter
     , hslogger
     , hspec
@@ -277,6 +277,6 @@ test-suite haskell-debug-adapter-test
     , resourcet
     , safe-exceptions
     , text
+  default-language: Haskell2010
   if impl(ghc < 8.10.0)
     buildable: False
-  default-language: Haskell2010

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,11 @@
+final: prev:
+with final.haskell.lib;
+with final.lib; {
+  haskellPackages = prev.haskellPackages.override (old: {
+    overrides = final.lib.composeExtensions (old.overrides or (_: _: {})) (
+      self: super: {
+        haskell-debug-adapter = buildFromSdist (self.callPackage ../default.nix {});
+      }
+    );
+  });
+}


### PR DESCRIPTION
Hi.

I am looking into adding support for haskell-debug-adapter to my [haskell-tools.nvim neovim plugin](https://github.com/mrcjkb/haskell-tools.nvim).
This means I may become interested in contributing to this project in the future. :smile: 

As I use [NixOS](https://nixos.org/) for development, I have added some infrastructure for using nix to build this project and run tests - which I am requesting to merge with this PR.

I have also added a GitHub action that runs the test suite on PR and push to `master`.

The nix flake uses [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) to

- run `hpack` to generate a cabal file from the `package.yaml`.
- run [`cabal2nix`](https://github.com/NixOS/cabal2nix) to generate a `default.nix` from the previously generated cabal file - which is then used in `nix/overlay.nix` to build the package.
- run [`alejandra`](https://github.com/kamadorueda/alejandra) for nix formatting.

This could potentially be extended to also run `hlint` and a Haskell formatter. I have omitted these, as they would result in modifications to the Haskell source files.
A potential downside to adding linters and formatters is that the CI could fail if someone uses a different version of `hlint` or the formatter than the version used in the nix build.
For anyone who has nix installed, this is not a problem, as long as they use `nix develop` to enter a nix shell with the correct versions of the packages installed.

The same applies to the `haskell-debug-adapter.cabal`, which is generated by `hpack`. The file has been changed in this PR, because the nix infrastructure uses a newer version of `hpack`.

`hpack` has lowered the lower bounds of the dependencies in `haskell-debug-adapter.cabal`.
This indicates that the `package.yaml` and stack resolver is not the source of truth for this build (?).
If need be, I can revert that change and remove the `hpack` pre-commit-hook. Although this discrepancy looks to me like it could lead to inconsistent results between stack and cabal builds.